### PR TITLE
177560439 demographic dropdown true false yes no fix

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -43,7 +43,7 @@
         <div class="form-group">
             <%= form.label :pasword, 'Password (6 char. minimum)', class:'required'%><br>
             <%= form.password_field :password, autocomplete: "new-password", class: 'form-control', :required => true, :minlength => 6, :oninput => "this.setCustomValidity('')", :oninvalid => "this.setCustomValidity('Password must be at least 6 characters')"%>
-        </div>  
+        </div>
 
         <div class="form-group">
           <%= form.label :password_confirmation, 'Confirm Password', class:'required'%><br>
@@ -56,7 +56,7 @@
       <div>
           <h1 class="lead">Demographic <br/> Info</h1>
       </div>
-      <div> 
+      <div>
         <div class="form-group">
           <%= form.label :gender, class: 'required'%>
           <%= form.select :gender, options_for_select(['Male','Female','Non-Binary', 'Prefer not to say']), {:prompt=>"Select Gender"}, {class: 'form-control', :required => true} %>
@@ -75,19 +75,19 @@
         <div class="form-group">
           <%= form.label :major, class: 'required' %>
           <%= form.select :major, options_for_select(['EECS','CS','other']), {:prompt=>"Select Major"}, {class: 'form-control', :required => true}%>
-        </div> 
+        </div>
 
         <div class="form-group">
           <%= form.label :transfer?, "Are you a transfer student?", class: 'required' %>
-          <%= form.select :transfer?,  options_for_select([true,false]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
-        </div>  
+          <%= form.select :transfer?,  options_for_select([['Yes',true],['No',false]]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
+        </div>
 
         <div class="form-group">
           <%= form.label :dsp?, "Are you a DSP student?", class: 'required' %>
-          <%= form.select :dsp?,  options_for_select([true,false]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
-        </div>  
-         
-      </div>   
+          <%= form.select :dsp?,  options_for_select([['Yes',true],['No',false]]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
+        </div>
+
+      </div>
     </div>
 
     <div class="form-row">
@@ -97,14 +97,15 @@
       <div>
 
         <div class="form-group">
-          <%= form.label :year, 'Years in School', class: 'required'%>
+          <%= form.label :year, 'Year in School', class: 'required'%>
           <%= form.select :year, options_for_select(['1st', '2nd', '3rd', '4th', 'Other']), {:prompt=>"Select Year"}, {class: 'form-control', :required => true} %>
         </div>
 
-        
+
         <div class="form-group">
           <%= form.label :privilige, 'For CS Scholars only. What CS Scholar Program Course?'%>
-          <%= form.select :privilege, options_for_select(['No', 'cs61a', 'cs61b', 'cs61c', 'cs70']), {:prompt=>"Select Tutor Type"}, {class: 'form-control '} %>
+          <!-- 3/31/21 why are these manually input and not being pulled from an admin-set list of CS Scholars courses? -->
+          <%= form.select :privilege, options_for_select(['N/A', 'cs61a', 'cs61b', 'cs61c', 'cs70']), {:prompt=>"Select Tutor Type"}, {class: 'form-control '} %>
         </div>
 
         <div class="form-group">

--- a/app/views/tutors/registrations/new.html.erb
+++ b/app/views/tutors/registrations/new.html.erb
@@ -48,7 +48,7 @@
         <div class="form-group">
             <%= form.label :password, 'Password (6 char. minimum)', class:'required'%><br>
             <%= form.password_field :password, autocomplete: "new-password", class: 'form-control', :required => true, :minlength => 6, :oninput => "this.setCustomValidity('')", :oninvalid => "this.setCustomValidity('Password must be at least 6 characters')"%>
-        </div>  
+        </div>
 
         <div class="form-group">
           <%= form.label :password_confirmation, 'Confirm Password', class:'required'%><br>
@@ -61,7 +61,7 @@
       <div>
           <h1 class="lead">Demographic <br/> Info</h1>
       </div>
-      <div> 
+      <div>
         <div class="form-group">
           <%= form.label :gender, class: 'required'%>
           <%= form.select :gender, options_for_select(['Male','Female','Non-Binary', 'Prefer not to say']), {:prompt=>"Select Gender"}, {class: 'form-control', :required => true} %>
@@ -70,18 +70,18 @@
         <div class="form-group">
           <%= form.label :major %>
           <%= form.text_field :major, class: 'form-control ', placeholder: 'eg. Computer Science'%>
-        </div> 
+        </div>
 
         <div class="form-group">
           <%= form.label :dsp?, "Are you a DSP student?", class: 'required' %>
-          <%= form.select :dsp?,  options_for_select([true,false]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
-        </div>   
+          <%= form.select :dsp?,  options_for_select([['Yes',true],['No',false]]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
+        </div>
 
         <div class="form-group">
           <%= form.label :transfer?, "Are you a transfer student?", class: 'required' %>
-          <%= form.select :transfer?,  options_for_select([true,false]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
-        </div>  
-      </div>   
+          <%= form.select :transfer?,  options_for_select([['Yes',true],['No',false]]), {:prompt=>"Select an Option"}, {class: 'form-control', :required => true}%>
+        </div>
+      </div>
     </div>
 
     <div class="form-row">
@@ -103,11 +103,11 @@
           <label class="required" style="width: 100%;">Preferred Classes</label>
           <%= fields_for :classes do |nc| %>
             <div class="form-control" style="height:unset;">
-              <% @berkeley_classes.each do|bc| %> 
+              <% @berkeley_classes.each do|bc| %>
                 <div class="bc-container">
                   <%= nc.check_box bc, {}, true, false%>
-                  <label for=<%="classes_" + bc%>> 
-                    <%= bc %> 
+                  <label for=<%="classes_" + bc%>>
+                    <%= bc %>
                   </label>
                 </div>
               <% end %>

--- a/features/new_tutor.feature
+++ b/features/new_tutor.feature
@@ -1,7 +1,7 @@
 Feature: Create a new Tutor
   As a first time tutor
   So that I can create an account
-  I want to input all the relevant fields: name, tutor type, and personal details like email      
+  I want to input all the relevant fields: name, tutor type, and personal details like email
 
   Scenario: create a new tutor called Emma
     Given I am on the home page
@@ -16,8 +16,8 @@ Feature: Create a new Tutor
     And I fill in "Confirm Password" with "password"
     And "Female" is selected for "Gender"
     And I fill in "Major" with "Computer Science"
-    And "false" is selected for "Are you a DSP student?"
-    And "false" is selected for "Are you a DSP student?"
+    And "No" is selected for "Are you a transfer student?"
+    And "No" is selected for "Are you a DSP student?"
     And "CSM (8-12 hours)" is selected for "Type of tutor"
     And I fill in "Sid" with "1234567890"
     And I check "classes[CS61A]"


### PR DESCRIPTION
# Tutor and Tutee Demographic Info Dropdown Option Fix

## Purpose

The purpose of this Pull Request is to fix a chore.

## User Story

When registering as a tutor or tutee, 
upon clicking "Are you a DSP Student?" dropdown, 
I should see "yes" or "no" instead of "true" or "false."

When registering as a tutor or tutee, 
upon clicking "Are you a transfer student?" dropdown, 
I should see "yes" or "no" instead of "true" or "false."

## Changes

app/views/tutors/registrations/new.html.erb
app/views/devise/registrations/new.html.erb

Added 'Yes' 'No' labels to mask the booleans exposed. 
Changed grammar for two questions and a default option about CS Scholar course for tutee registration options

## Screenshots

## Pivotal Tracker Links
https://www.pivotaltracker.com/story/show/177560439