### PR TITLE
Can now export tutor hours to a csv file

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -14,6 +14,15 @@ class AdminsController < ApplicationController
     @evaluations = Evaluation.all
   end
 
+  def tutor_hours_export
+    @tutors = Tutor.all
+
+    respond_to do |format|
+      format.html
+      format.csv {send_data @tutors.hours_to_csv, filename: "tutor-hours-#{Date.today}.csv"}
+    end
+  end
+
   def createAdminSession
     @admin = Admin.find(Admin.master_admin_index)
     if @admin and @admin.authenticate(params[:password])

--- a/app/models/tutor.rb
+++ b/app/models/tutor.rb
@@ -43,4 +43,24 @@ class Tutor < ApplicationRecord
 			return total_hours_helper(tutor)/total_weeks
 		end
 	end
+
+	def self.hours_to_csv
+		attributes = ["Tutor ID", "Tutor Name", "Total Hours"]
+
+	    CSV.generate(headers: true) do |csv|
+	      csv << attributes
+
+	      all.each do |tutor|
+	        csv << [tutor.id, tutor.name, tutor.hours]
+	      end
+	    end
+	end
+
+	def hours
+		evaluations.where(:took_place => true).where(:status => "Complete").sum(:hours)
+	end
+
+	def name
+		"#{first_name} #{last_name}"
+	end
 end

--- a/app/views/admins/tutor_hours.html.haml
+++ b/app/views/admins/tutor_hours.html.haml
@@ -31,3 +31,5 @@
                 %td= tutor.id
                 %td= tutor.first_name + " " + tutor.last_name
                 %td= tutor.evaluations.where(:took_place => true).where(:status => "Complete").sum(:hours)
+  
+  = link_to 'Export as CSV', admin_tutor_hours_export_path(format: "csv"), class: "float-right", download: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
+require 'csv'
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
   get 'admins/rating_tutors' => 'admins#rating_tutors', as: :admin_rating_tutors
   get 'admins/tutor_hours' => 'admins#tutor_hours', as: :admin_tutor_hours
+  get 'admins/tutor_hours/export' => 'admins#tutor_hours_export', as: :admin_tutor_hours_export
   # post 'admins/statistics_semester_update' => 'admins#updateStatisticsSemester', as: :admin_update_statistics_semester
   get 'admins/courses_update' => 'admins#update_courses', as: :admin_update_courses
   post 'admins/courses_update' => 'admins#post_update_courses', as: :admin_post_update_courses

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,3 +33,13 @@ Request.create!(:id=>"1",:tutee_id=>"1",:course_id=>"2",:meeting_length=>60,:sub
 Request.create!(:id=>"2",:tutee_id=>"2",:course_id=>"3",:meeting_length=>60,:subject=>"seeded request tutee 2", :created_at=>"2021-04-01 12:58:45 -0700", :updated_at=>"2021-04-01 12:58:45 -0700")
 Evaluation.create!(:id=>"2", :status=>"Pending")
 Meeting.create!(:id=>"2", :tutor_id=>"2", :tutee_id=>"2", :request_id=>"2", :evaluation_id=>"2")
+
+#2 past meetings that have occurred
+Request.create!(:id=>"3",:tutee_id=>"2",:course_id=>"3",:meeting_length=>120,:subject=>"seeded request tutee 2", :created_at=>"2021-04-01 12:58:45 -0700", :updated_at=>"2021-04-01 12:58:45 -0700")
+Evaluation.create!(:id=>"3", :took_place=>true, :status=>"Complete", :hours=>2)
+Meeting.create!(:id=>"3", :tutor_id=>"2", :tutee_id=>"2", :request_id=>"3", :evaluation_id=>"3")
+
+Request.create!(:id=>"4",:tutee_id=>"3",:course_id=>"3",:meeting_length=>120,:subject=>"seeded request tutee 2", :created_at=>"2021-04-01 12:58:45 -0700", :updated_at=>"2021-04-01 12:58:45 -0700")
+Evaluation.create!(:id=>"4", :took_place=>true, :status=>"Complete", :hours=>3)
+Meeting.create!(:id=>"4", :tutor_id=>"1", :tutee_id=>"3", :request_id=>"3", :evaluation_id=>"4")
+

--- a/features/admin_tutor_hours.feature
+++ b/features/admin_tutor_hours.feature
@@ -47,3 +47,15 @@ Feature: Show tutor hours
     And I can see tutor "alvin" with tutor hours 3
     And I can see tutor "duy" with tutor hours 0
     And I can see tutor "alex" with tutor hours 0
+
+  Scenario: Download tutor hours as csv
+    Given I am on the admin landing page
+    When I fill in "password" with "secureAdminPassword"
+    And press "Login"
+    Then I should be on the admin home page
+    And I click on "Tutor Hours" link
+    And I can see tutor "alvin" with tutor hours 3
+    And I can see tutor "duy" with tutor hours 0
+    And I can see tutor "alex" with tutor hours 0
+    Then I click on "Export as CSV" link
+    Then I should get a csv download with the filename "tutor-hours-" date

--- a/features/step_denifition/admin_steps.rb
+++ b/features/step_denifition/admin_steps.rb
@@ -128,3 +128,8 @@ When /I make an update for CS70 scholars to "(.*)"/ do |sid_list|
   page.find(:xpath, '//*[@id="update_cs70_scholars_button"]',visible: false).click
 end
 
+When /^I should get a csv download with the filename "([^\"]*)" date$/ do |filename|
+  filename = filename+ "#{Date.today}.csv"
+  page.driver.response.headers['Content-Disposition'].should include("filename=\"#{filename}\"")
+end
+


### PR DESCRIPTION
# Admin should be able to output all hours logged into a csv for further analysis

## Purpose

The purpose of this Pull Request is to add a button to the tutor hours page so that an admin can get a csv output of the tutor hours.

## Changes
app/controllers/admins_controller.rb
Added a new controller method that handles exporting to a csv

app/models/tutor.rb
Added a few helper methods

app/views/admins/tutor_hours.html.haml
Added a link to the new route

config/application.rb
Added "require csv"

config/routes.rb
Added a new route to handle exporting to a csv

db/seeds.rb
Added a few completed evaluations so that some hours would show up

features/admin_tutor_hours.feature
Created a new scenario for downloading the csv file, and checked if it was properly named and downloaded

features/step_denifition/admin_steps.rb
Added a step definition to assist with the new scenario

## Pivotal Tracker Links
https://www.pivotaltracker.com/story/show/177179509