### PR TITLE
177613384 admin validate tutors

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,5 +1,5 @@
 class AdminsController < ApplicationController
-  layout 'admin_layout', :only => [:home, :update_semester, :updateCurrentSemester, :rating_tutors, :update_courses, :tutor_hours, :update_password, :update_student_priorities]
+  layout 'admin_layout', :only => [:home, :update_semester, :updateCurrentSemester, :rating_tutors, :update_courses, :tutor_hours, :update_password, :update_student_priorities, :manage_tutors]
   before_action :set_admin, except: [:landing, :destroyAdminSession]
   before_action :check_logged_in, except: [:landing, :createAdminSession, :destroyAdminSession]
   
@@ -12,6 +12,23 @@ class AdminsController < ApplicationController
     @tutors = Tutor.all
     @meeting = Meeting.all
     @evaluations = Evaluation.all
+  end
+
+  def manage_tutors
+    @tutors = Tutor.all
+  end
+
+  def delete_tutor
+    email = params[:delete_tutor][:email]
+    tutor_to_delete = Tutor.where(:email => email).first
+    if tutor_to_delete.nil?
+      flash[:notice] = "No tutor with email #{email} exists."
+    else
+      flash[:message] = "Tutor #{email} successfully deleted."
+      meetings_to_delete = Meeting.where(:tutor => tutor_to_delete).delete_all
+      tutor_to_delete.destroy
+    end
+    redirect_to admin_manage_tutors_path
   end
 
   def createAdminSession

--- a/app/views/admins/manage_tutors.html.haml
+++ b/app/views/admins/manage_tutors.html.haml
@@ -1,0 +1,49 @@
+.container-fluid
+
+  / Breadcrumbs
+  %ol.breadcrumb
+    %li.breadcrumb-item
+      %a{:href => '#'} Admin
+    %li.breadcrumb-item.active Manage Tutors
+
+  / DataTables Example
+  .card.mb-3
+    .card-header
+      %span.glyphicon.glyphicon-list-alt Tutor Information
+    .card-body
+      .table-responsive
+        %table#dataTable.table.table-bordered{:cellspacing => '0', :width => '100%'}
+          %thead
+            %tr
+              %th Tutor ID
+              %th Tutor Name
+              %th Tutor Email
+
+            %tfoot
+              %tr
+              %th Tutor ID
+              %th Tutor Name
+              %th Tutor Email
+
+          %tbody
+            - @tutors.each do |tutor|
+              %tr
+                %td= tutor.id
+                %td= tutor.first_name + " " + tutor.last_name
+                %td= tutor.email
+
+  .card.mb-3
+    .card-header
+      %span.glyphicon.glyphicon-pencil
+      Delete Tutor
+    .card-body
+      - if flash[:curr_message]
+        .alert.alert-danger
+          %span.error= flash[:curr_message]
+      = form_tag admin_delete_tutor_path, class: 'container-fluid' do
+        .form-row
+          .form-group.col-md-4
+            = label :delete_tutor, :email, 'Enter tutor email:'
+            = text_field :delete_tutor, :email, class: 'form-control'
+
+        = submit_tag 'Delete Tutor', :id=>'delete_tutor',data: { confirm: "Are you sure? This will remove the tutor from the database as well as any meetings they tutored. This cannot be undone." }, class: 'btn btn-primary'

--- a/app/views/layouts/admin_layout.html.haml
+++ b/app/views/layouts/admin_layout.html.haml
@@ -45,6 +45,10 @@
           %a.nav-link{:href => admin_tutor_hours_path}
             %span.glyphicon.glyphicon-list-alt
             %span Tutor Hours
+        %li.nav-item.post{:class => "#{'active' if current_page?(admin_manage_tutors_path)}"}
+          %a.nav-link{:href => admin_manage_tutors_path}
+            %span.glyphicon.glyphicon-list-alt
+            %span Manage Tutors
         %li.nav-item.post{:class => "#{'active' if current_page?(admin_update_semester_path)}"}
           %a.nav-link{:href => admin_update_semester_path}
             %span.glyphicon.glyphicon-folder-close

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
 
   get 'admins/rating_tutors' => 'admins#rating_tutors', as: :admin_rating_tutors
   get 'admins/tutor_hours' => 'admins#tutor_hours', as: :admin_tutor_hours
+  get 'admins/manage_tutors' => 'admins#manage_tutors', as: :admin_manage_tutors
+  post 'admins/manage_tutors/delete_tutor' => 'admins#delete_tutor', as: :admin_delete_tutor
   # post 'admins/statistics_semester_update' => 'admins#updateStatisticsSemester', as: :admin_update_statistics_semester
   get 'admins/courses_update' => 'admins#update_courses', as: :admin_update_courses
   post 'admins/courses_update' => 'admins#post_update_courses', as: :admin_post_update_courses

--- a/db/migrate/20210401193404_create_initial_tables.rb
+++ b/db/migrate/20210401193404_create_initial_tables.rb
@@ -106,9 +106,5 @@ class CreateInitialTables < ActiveRecord::Migration[5.2]
       t.json :meta_values
       t.timestamps
     end
-
-
-
-
   end
 end

--- a/features/admin_manage_tutors.feature
+++ b/features/admin_manage_tutors.feature
@@ -1,0 +1,54 @@
+Feature: Validate Tutors
+  As the admin of the course,
+  So that random people can't register as tutors,
+  I want to be able to manage tutors by email.
+
+  Background: There exists these info
+    Given the following admins exist:
+      | id | password            | current_semester | statistics_semester |
+      | 1  | secureAdminPassword | Spring2019       | Spring2019          |
+
+    Given the following tutees exist:
+      | sid       | first_name  | last_name    | email               | privilege | birthdate  | password  | password_confirmation | confirmed_at        |
+      | 123456709 | thu         | nguyen       | thuu.ju@berkeley.edu | No        | 1992-01-01 | topsecret | topsecret             | 2019-05-07 05:07:48 |
+
+    Given the following courses exist:
+      | course_num | name  | semester |
+      | 1          | CS61A | Sp2019   |
+
+    Given the following requests exist:
+      | tutee_id | course_id | subject   |
+      | 1        | 1         | recursion |
+
+    Given the following tutors exist:
+      | type_of_tutor | grade_level | email              | first_name | last_name | password  | password_confirmation | confirmed_at |
+      | 20 hour TA    | Senior      | oskii@berkeley.edu | ana        | chang     | topsecret | topsecret             | 2019-05-07 05:07:48 |
+      | 20 hour TA    | Junior      | alexa@berkeley.edu | alexa      | chen      | topsecret | topsecret             | 2019-05-07 05:07:48 |
+
+    Given the following evaluations exist:
+      | status     | took_place |
+      | Complete   | true       |
+
+    Given "thu" has a meeting with tutor "alexa" meeting id "1" request with tutuee id "1" course name "CS61A" and evaluation status "Complete" knowledge "5" helpful "5" clarity "5"
+
+    Given "thu" has a meeting with tutor "alexa" meeting id "2" request with tutuee id "1" course name "CS61A" and evaluation status "Complete" knowledge "5" helpful "5" clarity "5"
+
+    Given "thu" has a meeting with tutor "alexa" meeting id "3" request with tutuee id "1" course name "CS61A" and evaluation status "Complete" knowledge "4" helpful "4" clarity "4"
+
+    And I am on the admin landing page
+    When I fill in "password" with "secureAdminPassword"
+    And press "Login"
+    Then I should be on the admin home page
+
+  Scenario: Delete both tutors
+    When I click on "Manage Tutors" link
+    Then I should be on the manage tutors page
+    And I can see the tutor name "alexa"
+    And I can see the tutor name "ana"
+    When I fill in "email" with "alexa@berkeley.edu"
+    And I press "Delete Tutor"
+    Then I should not see "alexa chen"
+    And I can see the tutor name "ana"
+    When I fill in "email" with "oskii@berkeley.edu"
+    And I press "Delete Tutor"
+    Then I should not see "ana chang"

--- a/features/step_denifition/admin_steps.rb
+++ b/features/step_denifition/admin_steps.rb
@@ -127,4 +127,3 @@ When /I make an update for CS70 scholars to "(.*)"/ do |sid_list|
   obj.set(sid_list.to_s.gsub(/, /, "\r\n"))
   page.find(:xpath, '//*[@id="update_cs70_scholars_button"]',visible: false).click
 end
-

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -60,6 +60,9 @@ module NavigationHelpers
     when /the admin home page/
       admin_home_path
 
+    when /the manage tutors page/
+      admin_manage_tutors_path
+
     when /tutor signup page/
       new_tutor_path
 


### PR DESCRIPTION
# Admin should be able to verify emails of tutors every semester (with a list)

## Purpose

The purpose of this Pull Request is to allow the admin to manage tutors.

## User Story

As the admin of the course,
So that random people can't register as tutors,
I want to whitelist emails of tutors.

## Changes

admins_controller.rb
Added a new controller to delete tutors

admin_layout.html.haml
added a button to the new page

routes.rb
added two routes for the manage tutors page and the delete tutor action

paths.rb
added a new path to the new page for cucumber

## Screenshots

## Pivotal Tracker Links
https://www.pivotaltracker.com/story/show/177613384