### PR TITLE
updated evaluations, meetings, and tutors to validate logged in when …

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -1,4 +1,5 @@
 class EvaluationsController < ApplicationController
+  before_action :check_tutee_logged_in, :except => [:public_edit, :public_show]
   layout 'tutee_layout', :only => [:edit, :index]
   def evaluation_params
     params.require(:evaluation).permit(:topics, :hours, :positive, :best, :feedback, :knowledgeable, :helpful, :clarity, :pacing, :final_comments, :took_place, :status, :hash_id)

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,5 +1,5 @@
 class MeetingsController < ApplicationController
-  # before_action :check_tutee_logged_in, :except => [:index]
+  before_action :check_tutee_logged_in, :except => [:index]
   layout 'tutee_layout'
 
   def meeting_params

--- a/app/controllers/tutors_controller.rb
+++ b/app/controllers/tutors_controller.rb
@@ -1,7 +1,7 @@
 require 'date'
 class TutorsController < ApplicationController
   before_action :set_tutor, only: [:show, :edit, :update, :find_students, :current_url_without_parameters]
-  before_action :check_tutor_logged_in, only: [:index, :show]
+  before_action :check_tutor_logged_in, except: [:index, :new, :create]
 
 
   # GET /tutors

--- a/features/tutor_select_student.feature
+++ b/features/tutor_select_student.feature
@@ -42,7 +42,10 @@ Feature: Tutor selects a student
 
   Scenario: Selecting a Student Successfully
     Given I am on the home page
-    And I go to the tutor page for "test@berkeley.edu"
+    And I press "Tutor Page"
+    And I fill in "username" with "test@berkeley.edu"
+    And I fill in "password" with "password"
+    And I press "Log in"
     And I go to the find students page for "test@berkeley.edu"
     And I should see "a"
     And I follow "CS61A"


### PR DESCRIPTION
# [URGENT] You should not be able to select students for another Tutor

## Purpose

The purpose of this Pull Request is to fix security issues where a user not logged could view certain pages.

## Changes

- controllers
    - added check_logged_in in before_action
- features/tutor_select_student.feature
    - previously the test did not log in but went to pages that you should be logged in to view, so now it logs in first

## Pivotal Tracker Links
https://www.pivotaltracker.com/story/show/177584569